### PR TITLE
String Metadata extraction refactor

### DIFF
--- a/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
+++ b/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
@@ -57,6 +57,9 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
         put("album", mmr.METADATA_KEY_ALBUM);
         put("genre", mmr.METADATA_KEY_GENRE);
         put("title", mmr.METADATA_KEY_TITLE);
+        put("trackNumber", mmr.METADATA_KEY_CD_TRACK_NUMBER);
+        put("bitRate", mmr.METADATA_KEY_BITRATE);
+        put("year", mmr.METADATA_KEY_YEAR);
     }};
 
     public RNReactNativeGetMusicFilesModule(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
+++ b/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
@@ -49,17 +49,16 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
     private int songsPerIteration = 0;
     private int version = Build.VERSION.SDK_INT;
     private String[] STAR = { "*" };
-    private MediaMetadataRetriever mmr = new MediaMetadataRetriever();
     private Map<String, Integer> metadataMap = new HashMap<String, Integer>(){{
-        put("artist", mmr.METADATA_KEY_ARTIST);
-        put("duration", mmr.METADATA_KEY_DURATION);
-        put("title", mmr.METADATA_KEY_TITLE);
-        put("album", mmr.METADATA_KEY_ALBUM);
-        put("genre", mmr.METADATA_KEY_GENRE);
-        put("title", mmr.METADATA_KEY_TITLE);
-        put("trackNumber", mmr.METADATA_KEY_CD_TRACK_NUMBER);
-        put("bitRate", mmr.METADATA_KEY_BITRATE);
-        put("year", mmr.METADATA_KEY_YEAR);
+        put("artist", MediaMetadataRetriever.METADATA_KEY_ARTIST);
+        put("duration", MediaMetadataRetriever.METADATA_KEY_DURATION);
+        put("title", MediaMetadataRetriever.METADATA_KEY_TITLE);
+        put("album", MediaMetadataRetriever.METADATA_KEY_ALBUM);
+        put("genre", MediaMetadataRetriever.METADATA_KEY_GENRE);
+        put("title", MediaMetadataRetriever.METADATA_KEY_TITLE);
+        put("trackNumber", MediaMetadataRetriever.METADATA_KEY_CD_TRACK_NUMBER);
+        put("bitRate", MediaMetadataRetriever.METADATA_KEY_BITRATE);
+        put("year", MediaMetadataRetriever.METADATA_KEY_YEAR);
     }};
 
     public RNReactNativeGetMusicFilesModule(ReactApplicationContext reactContext) {
@@ -146,6 +145,7 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
 
 
                 //FFmpegMediaMetadataRetriever mmr = new FFmpegMediaMetadataRetriever();
+                MediaMetadataRetriever mmr = new MediaMetadataRetriever();
 
                 int idColumn = musicCursor.getColumnIndex(android.provider.MediaStore.Audio.Media._ID);
 
@@ -155,12 +155,6 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
                             items = new WritableNativeMap();
 
                             long songId = musicCursor.getLong(idColumn);
-
-                            for (Map.Entry<String, Integer> entry : properties.entrySet()) {
-                                String value = mmr.extractMetadata(entry.getValue());
-                                System.out.println("--- " + entry.getKey() + " : " + value + " - " + entry.getValue().toString());
-                                items.putString(entry.getKey(), value);
-                            }
 
                             if (getIDFromSong) {
                                 String str = String.valueOf(songId);
@@ -181,6 +175,12 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
                                 items.putString("fileName", fileName);
 
                                 mmr.setDataSource(songPath);
+
+                                for (Map.Entry<String, Integer> entry : properties.entrySet()) {
+                                    String value = mmr.extractMetadata(entry.getValue());
+                                    System.out.println("--- " + entry.getKey() + " : " + value + " - " + entry.getValue().toString());
+                                    items.putString(entry.getKey(), value);
+                                }
 
                                 //String songTimeDuration = mmr.extractMetadata(FFmpegMediaMetadataRetriever.METADATA_KEY_DURATION);
                                 String songTimeDuration = mmr.extractMetadata(mmr.METADATA_KEY_DURATION);

--- a/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
+++ b/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
@@ -178,7 +178,6 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
 
                                 for (Map.Entry<String, Integer> entry : properties.entrySet()) {
                                     String value = mmr.extractMetadata(entry.getValue());
-                                    System.out.println("--- " + entry.getKey() + " : " + value + " - " + entry.getValue().toString());
                                     items.putString(entry.getKey(), value);
                                 }
 

--- a/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
+++ b/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
@@ -158,6 +158,7 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
 
                             for (Map.Entry<String, Integer> entry : properties.entrySet()) {
                                 String value = mmr.extractMetadata(entry.getValue());
+                                System.out.println("--- " + entry.getKey() + " : " + value + " - " + entry.getValue().toString());
                                 items.putString(entry.getKey(), value);
                             }
 

--- a/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
+++ b/android/src/main/java/com/cinder92/musicfiles/RNReactNativeGetMusicFilesModule.java
@@ -102,7 +102,7 @@ public class RNReactNativeGetMusicFilesModule extends ReactContextBaseJavaModule
         final Map<String, Integer> enabledMetaProperties = new HashMap<>();
         for (Map.Entry<String, Integer> entry : metadataMap.entrySet()) {
             String key = entry.getKey();
-            if (options.getBoolean(key)) {
+            if (options.hasKey(key) && options.getBoolean(key)) {
                 enabledMetaProperties.put(key, entry.getValue());
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "react-native-get-music-files",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "react-native-get-music-files",
   "version": "1.0.0",


### PR DESCRIPTION
Media Metadata properties can be separated in two categories:

- Complex properties (such as images)
- Simple string properties (Title, Artist, etc...)

For a local project, I need to access some simple properties that aren't current supported by this library (year, bitRate, trackNumber).

The objective of this PR is twofold:
- Refactor simple properties extraction to make it easier to add new properties
- Add the additional properties I need

This particular [commit](https://github.com/doomfalc/react-native-get-music-files/commit/0c62c6c42df5fe5f2e008d8b3f089803434f3bd9) illustrates how easy it is to add new "simple" properties.

I suppose the concept could be taken further to support ALL simple meta properties.